### PR TITLE
add user context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ function App() {
         setUser(res.data);
       })
       .catch((error) => {
-        toast.error(error);
+        console.log(error);
       });
   }, []);
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,39 +20,45 @@ import EditLocationLevel from "./components/Main/MyCarrot/EditLocationLevel/Edit
 import KakaoPage from "./KakaoLogin/KakaoPage";
 import SelectLocation from "./components/SelectLocation/SelectLocation";
 import Hearts from "./components/Hearts/Hearts";
+import { UserDto } from "./type/dto/user.dto";
+
+import { UserDispatchContext, UserStateContext } from "./context/user-context";
 
 function App() {
+  const [user, setUser] = useState<UserDto | undefined>(undefined);
   const token: string | null = localStorage.getItem("token");
 
   return (
-    <>
-      <Toaster />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/oauth/callback/kakao" element={<KakaoPage />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/select-location" element={<SelectLocation />} />
-          <Route path="/main" element={<Main />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/profile/edit" element={<EditProfile />} />
-          <Route path="/profile/sales" element={<Sales />} />
-          <Route path="/sales-history" element={<SalesHistory />} />
-          <Route path="/purchase-history" element={<PurchaseHistory />} />
-          <Route path="/hearts" element={<Hearts />} />
-          <Route path="/article/:id" element={<Article />} />
-          <Route path="/write" element={<WriteArticle />} />
-          <Route path="/verify-location" element={<LocationPage />} />
-          <Route path="/set-location" element={<EditLocationLevel />} />
-          <Route path="/search" element={<SearchPage />} />
-          <Route path="/request/:id" element={<RequestPage />} />
-          <Route
-            path="/*"
-            element={<Navigate replace to={token ? "/main" : "/login"} />}
-          />
-        </Routes>
-      </BrowserRouter>
-    </>
+    <UserDispatchContext.Provider value={setUser}>
+      <UserStateContext.Provider value={user}>
+        <Toaster />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/oauth/callback/kakao" element={<KakaoPage />} />
+            <Route path="/signup" element={<SignUp />} />
+            <Route path="/select-location" element={<SelectLocation />} />
+            <Route path="/main" element={<Main />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/profile/edit" element={<EditProfile />} />
+            <Route path="/profile/sales" element={<Sales />} />
+            <Route path="/sales-history" element={<SalesHistory />} />
+            <Route path="/purchase-history" element={<PurchaseHistory />} />
+            <Route path="/hearts" element={<Hearts />} />
+            <Route path="/article/:id" element={<Article />} />
+            <Route path="/write" element={<WriteArticle />} />
+            <Route path="/verify-location" element={<LocationPage />} />
+            <Route path="/set-location" element={<EditLocationLevel />} />
+            <Route path="/search" element={<SearchPage />} />
+            <Route path="/request/:id" element={<RequestPage />} />
+            <Route
+              path="/*"
+              element={<Navigate replace to={token ? "/main" : "/login"} />}
+            />
+          </Routes>
+        </BrowserRouter>
+      </UserStateContext.Provider>
+    </UserDispatchContext.Provider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import WriteArticle from "./components/Main/Home/Write/WriteArticle";
 import LocationPage from "./components/LocationPage/LocationPage";
 import EditProfile from "./components/Profile/EditProfile/EditProfile";
 import SearchPage from "./components/SearchPage/SearchPage";
-import { Toaster } from "react-hot-toast";
+import { toast, Toaster } from "react-hot-toast";
 import PurchaseHistory from "./components/PurchaseHistory/PurchaseHistory";
 import RequestPage from "./components/Requests/RequestPage";
 import Sales from "./components/Profile/Sales/Sales";
@@ -23,11 +23,21 @@ import Hearts from "./components/Hearts/Hearts";
 import { UserDto } from "./type/dto/user.dto";
 
 import { UserDispatchContext, UserStateContext } from "./context/user-context";
+import requester from "./apis/requester";
 
 function App() {
   const [user, setUser] = useState<UserDto | undefined>(undefined);
   const token: string | null = localStorage.getItem("token");
-
+  useEffect(() => {
+    requester
+      .get("/users/me/")
+      .then((res) => {
+        setUser(res.data);
+      })
+      .catch((error) => {
+        toast.error(error);
+      });
+  }, []);
   return (
     <UserDispatchContext.Provider value={setUser}>
       <UserStateContext.Provider value={user}>

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -4,9 +4,10 @@ import kakaoLogo from "../../icons/kakao-logo.png";
 import { ChangeEventHandler, useEffect, useState } from "react";
 import * as React from "react";
 import { Link, Navigate, useNavigate } from "react-router-dom";
-import { user } from "../../apis/requester";
+import requester, { user } from "../../apis/requester";
 import { toast } from "react-hot-toast";
 import { KAKAO_AUTH_URL } from "../../KakaoLogin/OAuth";
+import { useUserDispatch } from "../../context/user-context";
 
 type TLoginForm = {
   username: string;
@@ -21,6 +22,7 @@ const Login = () => {
 
   const navigate = useNavigate();
   const token: string | null = localStorage.getItem("token");
+  const setUser = useUserDispatch();
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setInputs({
@@ -37,6 +39,14 @@ const Login = () => {
         password: inputs.password,
       });
       localStorage.setItem("token", res.data.access_token);
+      requester
+        .get("/users/me/")
+        .then((res2) => {
+          setUser(res2.data);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
       navigate("/main");
     } catch (error) {
       toast.error("로그인 정보 틀림");

--- a/src/components/Main/Home/HomeHeader.tsx
+++ b/src/components/Main/Home/HomeHeader.tsx
@@ -7,19 +7,11 @@ import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import requester from "../../../apis/requester";
 import { GetMeDto } from "../../../type/dto/for-api/get-me.dto";
+import { useUserState } from "../../../context/user-context";
 
 const HomeHeader = (props: {}) => {
-  const [location, setLocation] = useState("");
   const navigate = useNavigate();
-
-  useEffect(() => {
-    requester.get<GetMeDto>("users/me/").then((res) => {
-      if (res.data.active_location) {
-        const splitResult = res.data.active_location.split(" ");
-        setLocation(splitResult[splitResult.length - 1]);
-      }
-    });
-  }, []);
+  const user = useUserState();
 
   const handleLocation = () => {
     console.log("위치 재지정하는 팝업");
@@ -36,10 +28,21 @@ const HomeHeader = (props: {}) => {
   const handleNotice = () => {
     console.log("알림창으로 push");
   };
+
+  if (!user) {
+    return <div className={styles.wrapper} />;
+  }
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.locationBox} onClick={handleLocation}>
-        <p className={styles.location}>{location}</p>
+        <p className={styles.location}>
+          {user.active_location
+            ? user.active_location.split(" ")[
+                user.active_location.split(" ").length - 1
+              ]
+            : "동네 정보 없음"}
+        </p>
         <img className={styles.locationArrow} src={DownArrow} alt="화살표" />
       </div>
       <div className={styles.headerImages}>

--- a/src/components/Main/Home/HomeHeader.tsx
+++ b/src/components/Main/Home/HomeHeader.tsx
@@ -37,9 +37,9 @@ const HomeHeader = (props: {}) => {
     <div className={styles.wrapper}>
       <div className={styles.locationBox} onClick={handleLocation}>
         <p className={styles.location}>
-          {user.first_location
-            ? user.first_location.split(" ")[
-                user.first_location.split(" ").length - 1
+          {user.is_first_location_active
+            ? user.first_location?.split(" ")[
+                user.first_location?.split(" ").length - 1
               ]
             : "동네 정보 없음"}
         </p>

--- a/src/components/Main/Home/HomeHeader.tsx
+++ b/src/components/Main/Home/HomeHeader.tsx
@@ -37,9 +37,9 @@ const HomeHeader = (props: {}) => {
     <div className={styles.wrapper}>
       <div className={styles.locationBox} onClick={handleLocation}>
         <p className={styles.location}>
-          {user.active_location
-            ? user.active_location.split(" ")[
-                user.active_location.split(" ").length - 1
+          {user.first_location
+            ? user.first_location.split(" ")[
+                user.first_location.split(" ").length - 1
               ]
             : "동네 정보 없음"}
         </p>

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -5,34 +5,22 @@ import User1 from "../../icons/Footer/user-selected.png";
 import User2 from "../../icons/Footer/user-unselected.png";
 import Set1 from "../../icons/Footer/settings-selected.png";
 import Set2 from "../../icons/Footer/settings-unselected.png";
+import * as React from "react";
 import { useEffect, useState } from "react";
 import HomeGoods from "./Home/HomeGoods";
 import HomeHeader from "./Home/HomeHeader";
 import { Navigate, useLocation } from "react-router-dom";
-import * as React from "react";
 import MyCarrot from "./MyCarrot/MyCarrot";
 import Settings from "./Settings/Settings";
-import requester from "../../apis/requester";
-import { toast } from "react-hot-toast";
-import { useUserDispatch } from "../../context/user-context";
 
 const Main = () => {
   const [write, setWrite] = useState(false);
   const [confirm, setConfirm] = useState(false);
   const [page, setPage] = useState("home");
-  const setUser = useUserDispatch();
 
   const loc = useLocation();
 
   useEffect(() => {
-    requester
-      .get("/users/me/")
-      .then((res) => {
-        setUser(res.data);
-      })
-      .catch((error) => {
-        toast.error(error);
-      });
     loc.state && setPage(loc.state.page);
     loc.state = null;
   }, []);

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -12,15 +12,27 @@ import { Navigate, useLocation } from "react-router-dom";
 import * as React from "react";
 import MyCarrot from "./MyCarrot/MyCarrot";
 import Settings from "./Settings/Settings";
+import requester from "../../apis/requester";
+import { toast } from "react-hot-toast";
+import { useUserDispatch } from "../../context/user-context";
 
 const Main = () => {
   const [write, setWrite] = useState(false);
   const [confirm, setConfirm] = useState(false);
   const [page, setPage] = useState("home");
+  const setUser = useUserDispatch();
 
   const loc = useLocation();
 
   useEffect(() => {
+    requester
+      .get("/users/me/")
+      .then((res) => {
+        setUser(res.data);
+      })
+      .catch((error) => {
+        toast.error(error);
+      });
     loc.state && setPage(loc.state.page);
     loc.state = null;
   }, []);

--- a/src/components/Main/Settings/Account.tsx
+++ b/src/components/Main/Settings/Account.tsx
@@ -13,22 +13,15 @@ import { formatPhoneNumber, regEmail, regPhone } from "../../SignUpPage/SignUp";
 import { GetMeDto } from "../../../type/dto/for-api/get-me.dto";
 import { UserDto } from "../../../type/dto/user.dto";
 import { toast } from "react-hot-toast";
+import { useUserDispatch, useUserState } from "../../../context/user-context";
 
 const Account = (props: { setAccount: Dispatch<SetStateAction<boolean>> }) => {
-  const [user, setUser] = useState<UserDto | null>(null);
   const [emailModal, setEmailModal] = useState(false);
   const [phoneModal, setPhoneModal] = useState(false);
   const [emailInput, setEmailInput] = useState("");
   const [phoneInput, setPhoneInput] = useState("");
-
-  useEffect(() => {
-    requester
-      .get<GetMeDto>("/users/me/")
-      .then((res) => {
-        setUser(res.data);
-      })
-      .catch((e) => {});
-  }, []);
+  const user = useUserState();
+  const setUser = useUserDispatch();
 
   if (!user) {
     return <div className={styles.wrapper} />;

--- a/src/context/user-context.ts
+++ b/src/context/user-context.ts
@@ -1,0 +1,21 @@
+import React, { Dispatch, SetStateAction, useContext } from "react";
+import { UserDto } from "../type/dto/user.dto";
+
+export const UserStateContext = React.createContext<UserDto | undefined>(
+  undefined
+);
+export const UserDispatchContext = React.createContext<
+  Dispatch<SetStateAction<UserDto | undefined>> | undefined
+>(undefined);
+
+export function useUserState() {
+  return useContext(UserStateContext);
+}
+
+export function useUserDispatch(): Dispatch<
+  SetStateAction<UserDto | undefined>
+> {
+  const dispatch = useContext(UserDispatchContext);
+  if (!dispatch) throw new Error("User Context Provider not found");
+  return dispatch;
+}

--- a/src/type/dto/user.dto.ts
+++ b/src/type/dto/user.dto.ts
@@ -6,11 +6,11 @@ export type UserDto = {
   name: string;
   nickname: string;
   phone: string;
-  active_location?: string;
-  active_range_of_location?: RangeOfLocation;
-  active_location_verified: boolean;
-  inactive_location?: string;
-  inactive_range_of_location?: RangeOfLocation;
-  inactive_location_verified: boolean;
-  is_active: boolean;
+  first_location?: string;
+  first_range_of_location?: RangeOfLocation;
+  first_location_verified: boolean;
+  second_location?: string;
+  second_range_of_location?: RangeOfLocation;
+  second_location_verified: boolean;
+  is_first: boolean;
 };

--- a/src/type/dto/user.dto.ts
+++ b/src/type/dto/user.dto.ts
@@ -9,6 +9,7 @@ export type UserDto = {
   first_location?: string;
   first_range_of_location?: RangeOfLocation;
   first_location_verified: boolean;
+  is_first_location_active: boolean;
   second_location?: string;
   second_range_of_location?: RangeOfLocation;
   second_location_verified: boolean;


### PR DESCRIPTION
#### UserContext: user, setUser를 글로벌하게 사용할 수 있는 useUserState(), useUserDispatch()를 추가했습니다.

1. useUserDispatch
예시 코드 제공 겸 설정 > 계정/정보 탭에서 이메일과 전화번호를 변경하는 부분에 적용하였습니다.
또한 App에서 마운트 시 setUser를 통해 값을 설정하도록 만들었습니다.
```typescript
const setUser = useUserDispatch();
```
프로필 업데이트 등에서 user 정보 수정 필요하실 때 setUser 받아오시면 됩니다.

2. useUserState()
그 외에 업데이트 없이 user 데이터만 필요한 곳에서는 아래 코드 사용하셔서 받아오시면 됩니다.
```typescript
const user = useUserState();
``` 
